### PR TITLE
build: changes edx_xblock_scorm repository from virtual-labx to eol

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -1,3 +1,3 @@
 -e git+https://github.com/eol-uchile/eol_list_grade@0d7688919bad8b229bff2948f31fedd76f1029d2#egg=eol_list_grade
--e git+https://github.com/eol-virtuallabx/edx_xblock_scorm@af72761ad08d5570e85d35d3ed7908618e707dac#egg=edx_xblock_scorm
+-e git+https://github.com/eol-uchile/edx_xblock_scorm@af72761ad08d5570e85d35d3ed7908618e707dac#egg=edx_xblock_scorm
 -e git+https://github.com/eol-virtuallabx/norteamericano-zoom-xblock@64b94dc6096689bc5e196d9a7cc4fd078a748b60#egg=norteamericano-zoom-xblock


### PR DESCRIPTION
Se modifica el repositorio de orignal de edx_xblock_scorm de virtual a eol, manteniendo el commit original

[https://github.com/eol-uchile/edx_xblock_scorm/commit/af72761ad08d5570e85d35d3ed7908618e707dac](https://github.com/eol-uchile/edx_xblock_scorm/commit/af72761ad08d5570e85d35d3ed7908618e707dac)